### PR TITLE
chore: update Dockerfile and add docker-compose.yml with an instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM openjdk:latest
+FROM openjdk:11
 
-ENV VERTICLE_FILE yggdrasil-0.0-SNAPSHOT-fat.jar
+# Yggdrasil build configuration
+ENV YGGDRASIL_VERSION 0.0
 
-ENV CONFIG_FILE config.json
+# Build environment preparation
+ENV LANG C.UTF-8
 
-ENV VERTICLE_HOME /usr/verticles
+# Build the jar
+WORKDIR /app
+COPY . /app/
+RUN ./gradlew
 
+# The default http port
 EXPOSE 8080
 
-COPY build/libs/$VERTICLE_FILE $VERTICLE_HOME/
-
-COPY src/main/conf/$CONFIG_FILE $VERTICLE_HOME/
-
-# Launch the verticle
-WORKDIR $VERTICLE_HOME
-ENTRYPOINT ["sh", "-c"]
-CMD ["exec java -jar $VERTICLE_FILE -conf $CONFIG_FILE"]
+ENTRYPOINT ["/bin/sh", "-c", "/usr/local/openjdk-11/bin/java -jar ./build/libs/yggdrasil-${YGGDRASIL_VERSION}-SNAPSHOT-fat.jar"]
+CMD ["-conf", "./src/main/conf/config.json"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ java -jar build/libs/yggdrasil-0.0-SNAPSHOT-fat.jar -conf src/main/conf/config.j
 The configuration file is optional. Open your browser to
 [http://localhost:8080](http://localhost:8080). You should see an `Yggdrasil v0.0` message.
 
+## Running Yggdrasil as a Docker container
+
+Build the image with the current context and creates the image `yggdrasil`:
+
+```shell
+docker-compose build
+```
+
+Run with docker-compose (by default, it exposes the port `8899` of the host machine):
+
+```shell
+docker-compose up
+```
 
 ## HTTP API Overview
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+  yggdrasil:
+    image: yggdrasil:latest
+    build:
+      context: .
+    container_name: yggdrasil
+    environment:
+      - YGGDRASIL_VERSION=0.0
+    ports:
+      - 8899:8080
+    restart: always
+


### PR DESCRIPTION
Hello team, this PR updates the Dockerfile which will be used to build an image `yggdrasil` from the working directory and to be used with docker-compose, along with a super simple instruction in `README.md`.
This is also meant to be used for deploying yggdrasil at https://yggdrasil.interactions.ics.unisg.ch/

P.S. I propose it to be merged to the main branch as the `feat/uc3-new` branch is seemingly having a build issue:

```console
root@b388501c2199:/app# ./gradlew --stacktrace
Downloading https://services.gradle.org/distributions/gradle-6.5-bin.zip
.........10%..........20%..........30%..........40%.........50%..........60%..........70%..........80%.........90%..........100%

Welcome to Gradle 6.5!

Here are the highlights of this release:
 - Experimental file-system watching
 - Improved version ordering
 - New samples

For more details see https://docs.gradle.org/6.5/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/app/cartago/build.gradle' line: 19

* What went wrong:
A problem occurred evaluating project ':cartago'.
> No signature of method: build_3w879ue2c4nbvu3h10jjcetg6.java() is applicable for argument types: (build_3w879ue2c4nbvu3h10jjcetg6$_run_closure1) values: [build_3w879ue2c4nbvu3h10jjcetg6$_run_closure1@5d676c5
c]
  Possible solutions: wait(), any(), wait(long), tap(groovy.lang.Closure), any(groovy.lang.Closure), each(groovy.lang.Closure)

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating project ':cartago'.
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:93)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.lambda$apply$0(DefaultScriptPluginFactory.java:133)
        at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:77)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:136)
        at org.gradle.configuration.BuildOperationScriptPlugin$1$1.run(BuildOperationScriptPlugin.java:69)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:395)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:387)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:242)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:150)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:84)
        at
…
Caused by: groovy.lang.MissingMethodException: No signature of method: build_3w879ue2c4nbvu3h10jjcetg6.java() is applicable for argument types: (build_3w879ue2c4nbvu3h10jjcetg6$_run_closure1) values: [build_3w
879ue2c4nbvu3h10jjcetg6$_run_closure1@5d676c5c]
Possible solutions: wait(), any(), wait(long), tap(groovy.lang.Closure), any(groovy.lang.Closure), each(groovy.lang.Closure)
        at build_3w879ue2c4nbvu3h10jjcetg6.run(/app/cartago/build.gradle:19)
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
        ... 146 more


* Get more help at https://help.gradle.org

BUILD FAILED in 9s
```