### PR TITLE
Add coverage badge to Yggdrasil

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,3 +48,12 @@ jobs:
           websub/build/reports
           build/reports
         if-no-files-found: error
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+        fail_ci_if_error: true
+        flags: unittests
+        name: codecov-umbrella
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Yggdrasil
 
+[![Codecov](https://codecov.io/gh/Interactions-HSG/yggdrasil/branch/main/graph/badge.svg?token=AAA)](https://codecov.io/gh/Interactions-HSG/yggdrasil)
+
 A platform for [Hypermedia Multi-Agent Systems (MAS)](https://hyperagents.org/) [1] built with
 [Vert.x](https://vertx.io/). The current implementation provides two core functionalities:
 


### PR DESCRIPTION
This PR adds a Codecov coverage badge to the repository by loading the coverage file on Codecov. Only the test CI configuration has been changed.