### PR TITLE
Fix environment configuration test

### DIFF
--- a/src/test/java/org/hyperagents/yggdrasil/MainVerticleTest.java
+++ b/src/test/java/org/hyperagents/yggdrasil/MainVerticleTest.java
@@ -53,20 +53,18 @@ public class MainVerticleTest {
   private static final String ARTIFACTS_PATH = "/artifacts/";
   private static final String CALLBACK_URL = "http://" + TEST_HOST + ":" + 8081 + "/";
 
-  private final List<Promise<Map.Entry<String, String>>> callbackMessages;
+  private List<Promise<Map.Entry<String, String>>> callbackMessages;
   private WebClient client;
   private int promiseIndex;
-
-  public MainVerticleTest() {
-    this.callbackMessages =
-      Stream.generate(Promise::<Map.Entry<String, String>>promise)
-            .limit(9)
-            .collect(Collectors.toList());
-  }
 
   @BeforeEach
   public void setUp(final Vertx vertx, final VertxTestContext ctx) {
     this.client = WebClient.create(vertx);
+    this.callbackMessages =
+      Stream.generate(Promise::<Map.Entry<String, String>>promise)
+            .limit(9)
+            .collect(Collectors.toList());
+    this.promiseIndex = 0;
     vertx
         .eventBus()
         .<String>consumer(
@@ -78,40 +76,39 @@ public class MainVerticleTest {
             this.promiseIndex++;
           }
         );
-    vertx
-        .deployVerticle(
-          new MainVerticle(),
-          new DeploymentOptions().setConfig(JsonObject.of(
-            "http-config",
-            JsonObject.of(
-              "host",
-              TEST_HOST,
-              "port",
-              TEST_PORT
-            ),
-            "notification-config",
-            JsonObject.of(
-              "enabled",
-              true
-            ),
-            "environment-config",
-            JsonObject.of(
-              "enabled",
-              true,
-              "known-artifacts",
-              JsonArray.of(
-                JsonObject.of(
-                  "class",
-                  COUNTER_ARTIFACT_CLASS,
-                  "template",
-                  "org.hyperagents.yggdrasil.artifacts.Counter"
-                )
-              )
-            )
-          ))
-        )
-        .compose(r -> vertx.deployVerticle(new CallbackServerVerticle()))
-        .onComplete(ctx.succeedingThenComplete());
+    vertx.deployVerticle(new CallbackServerVerticle())
+         .compose(r -> vertx.deployVerticle(
+           new MainVerticle(),
+           new DeploymentOptions().setConfig(JsonObject.of(
+             "http-config",
+             JsonObject.of(
+               "host",
+               TEST_HOST,
+               "port",
+               TEST_PORT
+             ),
+             "notification-config",
+             JsonObject.of(
+               "enabled",
+               true
+             ),
+             "environment-config",
+             JsonObject.of(
+               "enabled",
+               true,
+               "known-artifacts",
+               JsonArray.of(
+                 JsonObject.of(
+                   "class",
+                   COUNTER_ARTIFACT_CLASS,
+                   "template",
+                   "org.hyperagents.yggdrasil.artifacts.Counter"
+                 )
+               )
+             )
+           ))
+         ))
+         .onComplete(ctx.succeedingThenComplete());
   }
 
   @AfterEach


### PR DESCRIPTION
This fix switches the order in which the verticles are launched in the test. Now, the Yggdrasil main verticle is launched only after the one containing the callback Web server. This guarantees that the server is up and running when the requests arrive.

Closes #35 