### PR TITLE
Fix body deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ and for updating an agent body, URI `/workspaces/<wksp_id>/agents/<agt_id>`),
 can receive [Turtle](http://www.w3.org/TR/2014/REC-turtle-20140225/) payloads other than their default payloads,
 and the current implementation only validates the payload's syntax.
 
-For more information, see the [documentation website](interactions-hsg.github.io/yggdrasil/).
+For more information, see the [documentation website](https://interactions-hsg.github.io/yggdrasil/).
 
 ### WebSub
 
@@ -218,15 +218,23 @@ Link: <http://yggdrasil.andreiciortea.ro/workspaces/test>; rel="self"
 ```
 
 Using the discovered hub and topic IRIs,
-a client can subscribe for notification via a `POST` request that contains a JSON payload with the following fields
+a client can subscribe for notifications via a `POST` request that contains a JSON payload with the following fields
 (see the [W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/)) to the "hub" URL:
 
- * `hub.mode` (could be either "subscribe" or "unsubscribe")
- * `hub.topic` (the URI of the resource to subscribe to or unsubscribe from)
- * `hub.callback` (the URI to be notified by the Yggdrasil platform upon updates)
+* `hub.mode` (could be either "subscribe" or "unsubscribe")
+* `hub.topic` (the URI of the resource to subscribe to or unsubscribe from)
+* `hub.callback` (the URI to be notified by the Yggdrasil platform upon notifications)
 
-When a resource is created,
-updated or deleted,
+When a resource is created or updated,
 Yggdrasil issues a `POST` request with the resource representation to all registered callbacks.
+When a resource is deleted,
+Yggdrasil issues an empty `POST` request to all registered callbacks.
+When an agent starts or ends performing an action on an artifact in a workspace,
+Yggdrasil issues a JSON `POST` request to all registered callbacks with the following fields:
 
-For more information, see the [documentation website](interactions-hsg.github.io/yggdrasil/).
+* `eventType` (can be either "actionRequested," or "actionSucceeded," or "actionFailed")
+* `artifactName` (the name of the artifact on which the action is done)
+* `actionName` (the name of the action done on the artifact)
+* `cause` (present only if the "eventType" field is set to "actionFailed," the cause of failure)
+
+For more information, see the [documentation website](https://interactions-hsg.github.io/yggdrasil/).

--- a/README.md
+++ b/README.md
@@ -2,80 +2,99 @@
 
 [![codecov](https://codecov.io/gh/Interactions-HSG/yggdrasil/graph/badge.svg?token=DhAW8ZB5zr)](https://codecov.io/gh/Interactions-HSG/yggdrasil)
 
-A platform for [Hypermedia Multi-Agent Systems (MAS)](https://hyperagents.org/) [1] built with
-[Vert.x](https://vertx.io/). The current implementation provides two core functionalities:
+A platform for [Hypermedia Multi-Agent Systems (MAS)](https://hyperagents.org/) [1] built with [Vert.x](https://vertx.io/).
+The current implementation provides two core functionalities:
 
-* it allows to program and deploy hypermedia environments for autonomous agents that conform to the
-  _Agents & Artifacts_ meta-model [2]
-* it partially implements the [W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/)
-  and can act as a WebSub hub
+* it allows programming and deploying hypermedia environments for autonomous agents that conform to the _Agents & Artifacts_ metamodel [2]
+* it partially implements the [W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/) and can act as a WebSub hub
 
 #### References
 
 [1] Andrei Ciortea, Olivier Boissier, Alessandro Ricci. 2019. Engineering World-Wide Multi-Agent Systems
 with Hypermedia. In: Weyns D., Mascardi V., Ricci A. (eds) Engineering Multi-Agent Systems. EMAS 2018.
-Lecture Notes in Computer Science, vol 11375. Springer, Cham. https://doi.org/10.1007/978-3-030-25693-7_15
+Lecture Notes in Computer Science, vol 11375. Springer, Cham. [https://doi.org/10.1007/978-3-030-25693-7_15](https://doi.org/10.1007/978-3-030-25693-7_15)
 
 [2] Alessandro Ricci, Michele Piunti, and Mirko Viroli. 2011. Environment Programming in multi-agent
-systems: an artifact-based perspective. Autonomous Agents and Multi-Agent Systems, 23(2):158-192.
-
+systems: an artifact-based perspective. Autonomous Agents and Multi-Agent Systems, 23(2):158–192.
 
 ## Prerequisites
 
 * JDK 21+
+* Gradle 8.4+
 
 ## Building the project
 
-To build the project, just use:
+To build the project use:
 
 ```shell
 ./gradlew
 ```
 
-The default Gradle task `shadowJar` generates a fat-jar in the `build/libs` directory.
-
+The default Gradle task `shadowJar` generates a "fat" JAR file in the `build/libs` directory.
 
 ## Running Yggdrasil
 
-To start an Yggdrasil node:
+To start a Yggdrasil node:
 
 ```shell
 java -jar build/libs/yggdrasil-0.0.0-SNAPSHOT-all.jar -conf conf/localhost_memory_config.json
 ```
 
-The configuration file is optional. Open your browser to
-[http://localhost:8080](http://localhost:8080). You should see an `Yggdrasil v0.0.0` message.
+The configuration file is optional.
+Open your browser to [http://localhost:8080](http://localhost:8080).
+You should see a description of the platform like the following:
+
+```
+@prefix hmas: <https://purl.org/hmas/> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix saref: <https://w3id.org/saref#> .
+
+<http://localhost:8080/> a hmas:HypermediaMASPlatform, td:Thing;
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ];
+  td:hasActionAffordance [ a td:ActionAffordance;
+      td:name "createWorkspace";
+      td:hasForm [
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction;
+          hctl:hasTarget <http://localhost:8080/workspaces/>;
+          htv:methodName "POST"
+        ]
+    ];
+  td:title "yggdrasil".
+```
 
 ## Running Yggdrasil as a Docker container
 
-Build the image with the current context and creates the image `yggdrasil`:
+Run and build the Yggdrasil image in the project directory context
+(by default, the service is exposed on port `8899` of the host machine):
 
 ```shell
-docker-compose build
-```
-
-Run with docker-compose (by default, it exposes the port `8899` of the host machine):
-
-```shell
-docker-compose up
+docker compose up
 ```
 
 ## HTTP API Overview
 
-The HTTP API implements CRUD operations for 2 types of resources:
+The HTTP API implements CRUD operations for three types of resources:
 
-* workspaces (URI template: `/workspaces/<wksp_id>`)
-* artifacts (URI template: `/artifacts/<art_id>`)
+* workspaces and sub-workspaces (URI template: `/workspaces/<wksp_id>`)
+* artifacts (URI template: `/workspaces/<wksp_id>/artifacts/<art_id>`)
+* body artifacts (URI template: `/workspaces/<wksp_id>/agents/<agt_id>`)
 
-`POST` and `PUT` requests use [Turtle](http://www.w3.org/TR/2014/REC-turtle-20140225/) payloads
+### Caveats
+
+The `POST` requests for creating a workspace (URI `/workspaces/`),
+a sub-workspace (URI `/workspaces/<wksp_id>`) or an artifact (URI `/workspaces/<wksp_id>/artifact/`)
+can receive [Turtle](http://www.w3.org/TR/2014/REC-turtle-20140225/) payloads other than their default payloads,
 and the current implementation only validates the payload's syntax.
 
-`POST` requests can use the `Slug` header (see [RFC 5023](https://tools.ietf.org/html/rfc5023#section-9.7))
-to hint at a preferred IRI for a resource to be created. If the IRI is not already in use, it will
-be minted to the created resource.
-
-When creating a resource via `POST`, the resource to be created is identified in the Turtle payload
-via a null relative IRI:
+When creating a resource via `POST`,
+the resource to be created can be identified in the Turtle payload via a null relative IRI:
 
 ```shell
 curl -i -X POST \
@@ -85,37 +104,129 @@ curl -i -X POST \
   -d '<> a <https://purl.org/hmas/Workspace> .'
 ```
 
-When retrieving the representation of a resource from Yggdrasil, the HTTP response contains 2 `Link`
-header fields that advertise a WebSub hub that clients can subscribe to in order to receive
-notifications whenever the resource is updated (see the
-[W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/)).
-Sample request:
+The `POST` requests for creating a workspace (URI `/workspaces/`) or a sub-workspace (URI `/workspaces/<wksp_id>`)
+can use the `Slug` header (see [RFC 5023](https://tools.ietf.org/html/rfc5023#section-9.7))
+to hint at a preferred IRI for a resource to be created.
+If the IRI is not already in use, it will be minted to the created resource,
+otherwise, a new random URI will be generated.
+
+All `PUT` requests (for updating a workspace, URI `/workspaces/<wksp_id>`,
+for updating an artifact, URI `/workspaces/<wksp_id>/artifacts/<art_id>`,
+and for updating an agent body, URI `/workspaces/<wksp_id>/agents/<agt_id>`),
+can receive [Turtle](http://www.w3.org/TR/2014/REC-turtle-20140225/) payloads other than their default payloads,
+and the current implementation only validates the payload's syntax.
+
+For more information, see the [documentation website](interactions-hsg.github.io/yggdrasil/).
+
+### WebSub
+
+When retrieving the representation of a resource from Yggdrasil,
+the HTTP response contains 2 `Link` header fields
+that advertise a WebSub hub that clients can subscribe to receive notifications whenever the resource is updated
+(see the [W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/)).
+A sample request follows:
 
 ```shell
-GET /workspaces/wksp1 HTTP/1.1
+GET /workspaces/test HTTP/1.1
 Host: yggdrasil.andreiciortea.ro
 
 HTTP/1.1 200 OK
 Content-Type: text/turtle
-Link: <http://yggdrasil.andreiciortea.ro/hub>; rel="hub"
-Link: <http://yggdrasil.andreiciortea.ro/workspaces/wksp1>; rel="self"
+Link: <http://yggdrasil.andreiciortea.ro/hub/>; rel="hub"
+Link: <http://yggdrasil.andreiciortea.ro/workspaces/test>; rel="self"
 
-<http://yggdrasil.andreiciortea.ro/workspaces/wksp1>
-  a <https://purl.org/hmas/Workspace> ;
-  <https://purl.org/hmas/hasName> "wksp1" ;
-  <https://purl.org/hmas/contains>
-    <http://85.204.10.233:8080/artifacts/hue1> ,
-    <http://yggdrasil.andreiciortea.ro/artifacts/event-gen> .
+@prefix hmas: <https://purl.org/hmas/> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix saref: <https://w3id.org/saref#> .
+
+<http://localhost:8080/workspaces/test> a td:Thing, hmas:Workspace;
+  td:hasActionAffordance [ a td:ActionAffordance;
+      td:name "joinWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/join>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ]
+    ], [ a td:ActionAffordance;
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/artifacts/>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ];
+      td:hasInputSchema [ a js:ObjectSchema;
+          js:properties [ a js:StringSchema;
+              js:propertyName "artifactName"
+            ], [ a js:ArraySchema;
+              js:propertyName "initParams"
+            ], [ a js:StringSchema;
+              js:propertyName "artifactClass";
+              js:enum <http://example.org/Adder>, <http://example.org/Counter>
+            ];
+          js:required "artifactName", "artifactClass"
+        ];
+      td:name "makeArtifact"
+    ], [ a td:ActionAffordance;
+      td:name "focus";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/focus>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ];
+      td:hasInputSchema [ a js:ObjectSchema;
+          js:properties [ a js:StringSchema;
+              js:propertyName "artifactName"
+            ], [ a js:StringSchema;
+              js:propertyName "callbackIri"
+            ];
+          js:required "artifactName", "callbackIri"
+        ]
+    ], [ a td:ActionAffordance;
+      td:name "quitWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/leave>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ]
+    ], [ a td:ActionAffordance;
+      td:name "createSubWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction;
+          hctl:hasTarget <http://localhost:8080/workspaces/test>
+        ]
+    ] ;
+  td:title "test";
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ];
+  hmas:isHostedOn <http://localhost:8080/>;
+  hmas:contains <http://localhost:8080/workspaces/test/agents/test>;
+  hmas:contains <http://localhost:8080/workspaces/sub> .
+
+<http://localhost:8080/> a hmas:HypermediaMASPlatform .
+<http://localhost:8080/workspaces/sub> a hmas:Workspace .
+<http://localhost:8080/workspaces/test/agents/test> a hmas:Artifact .
 ```
 
-Using the discovered hub and topic IRIs, a client can subscribe for notification via a `POST` request
-that contains a JSON payload with the following fields (see the
-[W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/)):
+Using the discovered hub and topic IRIs,
+a client can subscribe for notification via a `POST` request that contains a JSON payload with the following fields
+(see the [W3C WebSub recommendation](https://www.w3.org/TR/2018/REC-websub-20180123/)) to the "hub" URL:
 
- * `hub.mode`
- * `hub.topic`
- * `hub.callback`
+ * `hub.mode` (could be either "subscribe" or "unsubscribe")
+ * `hub.topic` (the URI of the resource to subscribe to or unsubscribe from)
+ * `hub.callback` (the URI to be notified by the Yggdrasil platform upon updates)
 
-When a resource is updated, Yggdrasil issues `POST` requests with the (updated) resource
-representation to all registered callbacks.
+When a resource is created,
+updated or deleted,
+Yggdrasil issues a `POST` request with the resource representation to all registered callbacks.
 
+For more information, see the [documentation website](interactions-hsg.github.io/yggdrasil/).

--- a/yggdrasil-core/src/main/java/org/hyperagents/yggdrasil/store/RdfStoreVerticle.java
+++ b/yggdrasil-core/src/main/java/org/hyperagents/yggdrasil/store/RdfStoreVerticle.java
@@ -469,12 +469,15 @@ public class RdfStoreVerticle extends AbstractVerticle {
               final var artifactIri = requestIri.toString();
               final var workspaceIri =
                   RdfModelUtils.createIri(
-                    Pattern.compile("^(https?://.*?:[0-9]+/workspaces/.*?)/(?:artifacts|agents)/.*?$")
-                           .matcher(artifactIri)
-                           .results()
-                           .map(r -> r.group(1))
-                           .findFirst()
-                           .orElseThrow()
+                      Pattern
+                        .compile(
+                          "^(https?://.*?:[0-9]+/workspaces/.*?)/(?:artifacts|agents)/.*?$"
+                        )
+                        .matcher(artifactIri)
+                        .results()
+                        .map(r -> r.group(1))
+                        .findFirst()
+                        .orElseThrow()
                   );
               this.store
                   .getEntityModel(workspaceIri)

--- a/yggdrasil-core/src/main/java/org/hyperagents/yggdrasil/store/RdfStoreVerticle.java
+++ b/yggdrasil-core/src/main/java/org/hyperagents/yggdrasil/store/RdfStoreVerticle.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.function.Failable;
 import org.apache.http.HttpStatus;
@@ -468,7 +469,12 @@ public class RdfStoreVerticle extends AbstractVerticle {
               final var artifactIri = requestIri.toString();
               final var workspaceIri =
                   RdfModelUtils.createIri(
-                    artifactIri.substring(0, artifactIri.indexOf("/artifacts"))
+                    Pattern.compile("^(https?://.*?:[0-9]+/workspaces/.*?)/(?:artifacts|agents)/.*?$")
+                           .matcher(artifactIri)
+                           .results()
+                           .map(r -> r.group(1))
+                           .findFirst()
+                           .orElseThrow()
                   );
               this.store
                   .getEntityModel(workspaceIri)

--- a/yggdrasil-core/src/test/java/org/hyperagents/yggdrasil/store/RdfStoreVerticleCreateTest.java
+++ b/yggdrasil-core/src/test/java/org/hyperagents/yggdrasil/store/RdfStoreVerticleCreateTest.java
@@ -34,6 +34,8 @@ public class RdfStoreVerticleCreateTest {
   private static final String URIS_EQUAL_MESSAGE = "The URIs should be equal";
   private static final String WORKSPACES_PATH = "http://localhost:8080/workspaces/";
   private static final String TEST_WORKSPACE_NAME = "test";
+  private static final String PLATFORM_FILE = "platform_test_td.ttl";
+  private static final String TEST_WORKSPACE_FILE = "output_test_workspace_td.ttl";
 
   private final BlockingQueue<HttpNotificationDispatcherMessage> notificationQueue;
   private RdfStoreMessagebox storeMessagebox;
@@ -121,12 +123,12 @@ public class RdfStoreVerticleCreateTest {
       throws URISyntaxException, IOException {
     final var platformRepresentation =
         Files.readString(
-          Path.of(ClassLoader.getSystemResource("platform_test_td.ttl").toURI()),
+          Path.of(ClassLoader.getSystemResource(PLATFORM_FILE).toURI()),
           StandardCharsets.UTF_8
         );
     final var outputWorkspaceRepresentation =
         Files.readString(
-          Path.of(ClassLoader.getSystemResource("output_test_workspace_td.ttl").toURI()),
+          Path.of(ClassLoader.getSystemResource(TEST_WORKSPACE_FILE).toURI()),
           StandardCharsets.UTF_8
         );
     this.assertWorkspaceCreated(ctx, outputWorkspaceRepresentation, platformRepresentation)
@@ -168,11 +170,11 @@ public class RdfStoreVerticleCreateTest {
     this.assertWorkspaceCreated(
           ctx,
           Files.readString(
-              Path.of(ClassLoader.getSystemResource("output_test_workspace_td.ttl").toURI()),
+              Path.of(ClassLoader.getSystemResource(TEST_WORKSPACE_FILE).toURI()),
               StandardCharsets.UTF_8
           ),
           Files.readString(
-              Path.of(ClassLoader.getSystemResource("platform_test_td.ttl").toURI()),
+              Path.of(ClassLoader.getSystemResource(PLATFORM_FILE).toURI()),
               StandardCharsets.UTF_8
           )
         )
@@ -254,11 +256,11 @@ public class RdfStoreVerticleCreateTest {
     this.assertWorkspaceCreated(
           ctx,
           Files.readString(
-              Path.of(ClassLoader.getSystemResource("output_test_workspace_td.ttl").toURI()),
+              Path.of(ClassLoader.getSystemResource(TEST_WORKSPACE_FILE).toURI()),
               StandardCharsets.UTF_8
           ),
           Files.readString(
-              Path.of(ClassLoader.getSystemResource("platform_test_td.ttl").toURI()),
+              Path.of(ClassLoader.getSystemResource(PLATFORM_FILE).toURI()),
               StandardCharsets.UTF_8
           )
         )
@@ -339,11 +341,11 @@ public class RdfStoreVerticleCreateTest {
     this.assertWorkspaceCreated(
           ctx,
           Files.readString(
-              Path.of(ClassLoader.getSystemResource("output_test_workspace_td.ttl").toURI()),
+              Path.of(ClassLoader.getSystemResource(TEST_WORKSPACE_FILE).toURI()),
               StandardCharsets.UTF_8
           ),
           Files.readString(
-              Path.of(ClassLoader.getSystemResource("platform_test_td.ttl").toURI()),
+              Path.of(ClassLoader.getSystemResource(PLATFORM_FILE).toURI()),
               StandardCharsets.UTF_8
           )
         )

--- a/yggdrasil-core/src/test/java/org/hyperagents/yggdrasil/store/RdfStoreVerticleDeleteTest.java
+++ b/yggdrasil-core/src/test/java/org/hyperagents/yggdrasil/store/RdfStoreVerticleDeleteTest.java
@@ -34,6 +34,7 @@ public class RdfStoreVerticleDeleteTest {
   private static final String URIS_EQUAL_MESSAGE = "The URIs should be equal";
   private static final String PLATFORM_URI = "http://localhost:8080/";
   private static final String TEST_WORKSPACE_URI = PLATFORM_URI + "workspaces/test";
+  private static final String TEST_AGENT_BODY_URI = TEST_WORKSPACE_URI + "/agents/test";
   private static final String SUB_WORKSPACE_URI = PLATFORM_URI + "workspaces/sub";
   private static final String COUNTER_ARTIFACT_URI = SUB_WORKSPACE_URI + "/artifacts/c0";
   private static final String COUNTER_ARTIFACT_FILE = "c0_counter_artifact_sub_td.ttl";
@@ -157,7 +158,7 @@ public class RdfStoreVerticleDeleteTest {
                 bodyDeletionMessage.content()
             );
             Assertions.assertEquals(
-                TEST_WORKSPACE_URI + "/agents/test",
+                TEST_AGENT_BODY_URI,
                 bodyDeletionMessage.requestIri(),
                 URIS_EQUAL_MESSAGE
             );
@@ -421,7 +422,7 @@ public class RdfStoreVerticleDeleteTest {
         );
     this.assertWorkspaceTreeCreated(ctx)
         .compose(r -> this.storeMessagebox.sendMessage(new RdfStoreMessage.DeleteEntity(
-          TEST_WORKSPACE_URI + "/agents/test"
+          TEST_AGENT_BODY_URI
         )))
         .onSuccess(r -> {
           RdfStoreVerticleTestHelpers.assertEqualsThingDescriptions(
@@ -450,7 +451,7 @@ public class RdfStoreVerticleDeleteTest {
                 deletionMessage.content()
             );
             Assertions.assertEquals(
-                TEST_WORKSPACE_URI + "/agents/test",
+                TEST_AGENT_BODY_URI,
                 deletionMessage.requestIri(),
                 URIS_EQUAL_MESSAGE
             );
@@ -459,7 +460,7 @@ public class RdfStoreVerticleDeleteTest {
           }
         })
         .compose(r -> this.storeMessagebox.sendMessage(new RdfStoreMessage.GetEntity(
-          TEST_WORKSPACE_URI + "/agents/test"
+          TEST_AGENT_BODY_URI
         )))
         .onFailure(RdfStoreVerticleTestHelpers::assertNotFound)
         .recover(r -> this.storeMessagebox.sendMessage(new RdfStoreMessage.GetEntity(

--- a/yggdrasil-core/src/test/resources/output_test_agent_body_test.ttl
+++ b/yggdrasil-core/src/test/resources/output_test_agent_body_test.ttl
@@ -1,0 +1,19 @@
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix hmas: <https://purl.org/hmas/> .
+
+<http://localhost:8080/workspaces/test/agents/test> a td:Thing, <https://example.org/Body>,
+    hmas:Artifact;
+  td:title "test";
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ];
+  hmas:isContainedIn <http://localhost:8080/workspaces/test>;
+  <https://example.org/isBodyOf> <http://localhost:8080/agents/test> .
+
+<http://localhost:8080/workspaces/test> a hmas:Workspace .
+
+<http://localhost:8080/agents/test> a hmas:Agent .

--- a/yggdrasil-core/src/test/resources/test_agent_body_test.ttl
+++ b/yggdrasil-core/src/test/resources/test_agent_body_test.ttl
@@ -1,0 +1,14 @@
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix hmas: <https://purl.org/hmas/> .
+
+<http://localhost:8080/workspaces/test/agents/test> a td:Thing, <https://example.org/Body>,
+    hmas:Artifact;
+  td:title "test";
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ] .
+

--- a/yggdrasil-core/src/test/resources/test_workspace_body_td.ttl
+++ b/yggdrasil-core/src/test/resources/test_workspace_body_td.ttl
@@ -1,0 +1,78 @@
+@prefix hmas: <https://purl.org/hmas/> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix saref: <https://w3id.org/saref#> .
+
+<http://localhost:8080/workspaces/test> a td:Thing, hmas:Workspace;
+  td:hasActionAffordance [ a td:ActionAffordance;
+      td:name "joinWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/join>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ]
+    ], [ a td:ActionAffordance;
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/artifacts/>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ];
+      td:hasInputSchema [ a js:ObjectSchema;
+          js:properties [ a js:StringSchema;
+              js:propertyName "artifactName"
+            ], [ a js:ArraySchema;
+              js:propertyName "initParams"
+            ], [ a js:StringSchema;
+              js:propertyName "artifactClass";
+              js:enum <http://example.org/Adder>, <http://example.org/Counter>
+            ];
+          js:required "artifactName", "artifactClass"
+        ];
+      td:name "makeArtifact"
+    ], [ a td:ActionAffordance;
+      td:name "focus";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/focus>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ];
+      td:hasInputSchema [ a js:ObjectSchema;
+          js:properties [ a js:StringSchema;
+              js:propertyName "artifactName"
+            ], [ a js:StringSchema;
+              js:propertyName "callbackIri"
+            ];
+          js:required "artifactName", "callbackIri"
+        ]
+    ], [ a td:ActionAffordance;
+      td:name "quitWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/leave>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ]
+    ], [ a td:ActionAffordance;
+      td:name "createSubWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction;
+          hctl:hasTarget <http://localhost:8080/workspaces/test>
+        ]
+    ] ;
+  td:title "test";
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ];
+  hmas:isHostedOn <http://localhost:8080/>;
+  hmas:contains <http://localhost:8080/workspaces/test/agents/test> .
+
+<http://localhost:8080/> a hmas:HypermediaMASPlatform .
+<http://localhost:8080/workspaces/test/agents/test> a hmas:Artifact .

--- a/yggdrasil-core/src/test/resources/test_workspace_sub_body_td.ttl
+++ b/yggdrasil-core/src/test/resources/test_workspace_sub_body_td.ttl
@@ -1,0 +1,80 @@
+@prefix hmas: <https://purl.org/hmas/> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix saref: <https://w3id.org/saref#> .
+
+<http://localhost:8080/workspaces/test> a td:Thing, hmas:Workspace;
+  td:hasActionAffordance [ a td:ActionAffordance;
+      td:name "joinWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/join>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ]
+    ], [ a td:ActionAffordance;
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/artifacts/>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ];
+      td:hasInputSchema [ a js:ObjectSchema;
+          js:properties [ a js:StringSchema;
+              js:propertyName "artifactName"
+            ], [ a js:ArraySchema;
+              js:propertyName "initParams"
+            ], [ a js:StringSchema;
+              js:propertyName "artifactClass";
+              js:enum <http://example.org/Adder>, <http://example.org/Counter>
+            ];
+          js:required "artifactName", "artifactClass"
+        ];
+      td:name "makeArtifact"
+    ], [ a td:ActionAffordance;
+      td:name "focus";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/focus>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ];
+      td:hasInputSchema [ a js:ObjectSchema;
+          js:properties [ a js:StringSchema;
+              js:propertyName "artifactName"
+            ], [ a js:StringSchema;
+              js:propertyName "callbackIri"
+            ];
+          js:required "artifactName", "callbackIri"
+        ]
+    ], [ a td:ActionAffordance;
+      td:name "quitWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:hasTarget <http://localhost:8080/workspaces/test/leave>;
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction
+        ]
+    ], [ a td:ActionAffordance;
+      td:name "createSubWorkspace";
+      td:hasForm [
+          htv:methodName "POST";
+          hctl:forContentType "application/json";
+          hctl:hasOperationType td:invokeAction;
+          hctl:hasTarget <http://localhost:8080/workspaces/test>
+        ]
+    ] ;
+  td:title "test";
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ];
+  hmas:isHostedOn <http://localhost:8080/>;
+  hmas:contains <http://localhost:8080/workspaces/test/agents/test>;
+  hmas:contains <http://localhost:8080/workspaces/sub> .
+
+<http://localhost:8080/> a hmas:HypermediaMASPlatform .
+<http://localhost:8080/workspaces/sub> a hmas:Workspace .
+<http://localhost:8080/workspaces/test/agents/test> a hmas:Artifact .

--- a/yggdrasil-core/src/test/resources/updated_test_agent_body_test.ttl
+++ b/yggdrasil-core/src/test/resources/updated_test_agent_body_test.ttl
@@ -1,0 +1,49 @@
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix wotsec: <https://www.w3.org/2019/wot/security#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix js: <https://www.w3.org/2019/wot/json-schema#> .
+@prefix hmas: <https://purl.org/hmas/> .
+
+<http://localhost:8080/workspaces/test/agents/test> a td:Thing, <https://example.org/Body>,
+    hmas:Artifact;
+  td:title "test";
+  td:hasSecurityConfiguration [ a wotsec:NoSecurityScheme
+    ];
+  td:hasActionAffordance [
+    a td:ActionAffordance, <https://example.org/kqml#RequestTell>;
+    td:title "tell";
+    td:name "tell";
+    td:hasForm [
+        htv:methodName "POST";
+        hctl:hasTarget <http://localhost:8081/inbox>;
+        hctl:forContentType "application/json";
+        hctl:hasOperationType td:invokeAction
+    ];
+    td:hasInputSchema [
+        a js:ObjectSchema;
+        js:properties [
+            a js:StringSchema, <https://example.org/kqml#Performative>;
+            js:propertyName "performative";
+            js:enum "tell";
+        ], [
+            a js:StringSchema, hmas:Agent;
+            js:propertyName "sender";
+        ], [
+            a js:StringSchema, hmas:Agent;
+            js:propertyName "receiver";
+            js:enum "http://localhost:8080/workspaces/test/agents/test";
+        ], [
+            a js:StringSchema, <https://example.org/kqml#PropositionalContent>;
+            js:propertyName "content";
+        ];
+        js:required "performative", "sender", "receiver", "content";
+    ];
+  ];
+  hmas:isContainedIn <http://localhost:8080/workspaces/test>;
+  <https://example.org/isBodyOf> <http://localhost:8080/agents/test> .
+
+<http://localhost:8080/workspaces/test> a hmas:Workspace .
+
+<http://localhost:8080/agents/test> a hmas:Agent .


### PR DESCRIPTION
This PR fixes the bug for which the deletion of body artifacts was not correctly handled. 

Since the extraction of the artifact URIs was considering only the ones following the format "/workspaces/:wkspid/artifacts/:artid," body artifacts URI generated an exception when deleted. After the change, the deletion handler in the RDFStore verticle also considers resources with URIs like "/workspaces/:wkspid/agents/:agt."

This PR addresses also:
* Fixes the README document by removing incorrect information from all previous changes and links to the documentation website for more details.
* Adds more tests for checking body artifact creation, update, and deletion

Closes #16 