### PR TITLE
Fix bugs from a distant past

### DIFF
--- a/yggdrasil-cartago/src/main/java/org/hyperagents/yggdrasil/cartago/CartagoVerticle.java
+++ b/yggdrasil-cartago/src/main/java/org/hyperagents/yggdrasil/cartago/CartagoVerticle.java
@@ -338,7 +338,9 @@ public class CartagoVerticle extends AbstractVerticle {
               : params
             );
           })
-          .orElseGet(() -> new Op(action));
+          .orElseGet(() -> registry.hasFeedbackParam(artifactName, action)
+                           ? new Op(action, feedbackParameter)
+                           : new Op(action));
     final var promise = Promise.<Void>promise();
     final var workspace = this.workspaceRegistry.getWorkspace(workspaceName).orElseThrow();
     final var agentName = this.getAgentNameFromAgentUri(agentUri);

--- a/yggdrasil-cartago/src/main/java/org/hyperagents/yggdrasil/cartago/artifacts/HypermediaArtifact.java
+++ b/yggdrasil-cartago/src/main/java/org/hyperagents/yggdrasil/cartago/artifacts/HypermediaArtifact.java
@@ -10,6 +10,7 @@ import ch.unisg.ics.interactions.wot.td.security.NoSecurityScheme;
 import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import java.net.URI;
 import java.util.ArrayList;
@@ -30,12 +31,18 @@ import org.hyperagents.yggdrasil.utils.impl.HttpInterfaceConfigImpl;
 import org.hyperagents.yggdrasil.utils.impl.RepresentationFactoryImpl;
 
 public abstract class HypermediaArtifact extends Artifact {
+  private static final String DEFAULT_CONFIG_VALUE = "default";
+
   private final ListMultimap<String, ActionAffordance> actionAffordances =
       Multimaps.newListMultimap(new HashMap<>(), ArrayList::new);
   private final Model metadata = new LinkedHashModel();
   private final Set<String> feedbackActions = new HashSet<>();
   private final Map<String, UnaryOperator<Object>> responseConverterMap = new HashMap<>();
-  private HttpInterfaceConfig httpConfig = new HttpInterfaceConfigImpl(JsonObject.of());
+  private HttpInterfaceConfig httpConfig = Vertx.currentContext()
+                                                .owner()
+                                                .sharedData()
+                                                .<String, HttpInterfaceConfig>getLocalMap("http-config")
+                                                .get(DEFAULT_CONFIG_VALUE);
   private RepresentationFactory representationFactory =
       new RepresentationFactoryImpl(this.httpConfig);
   private SecurityScheme securityScheme = new NoSecurityScheme();


### PR DESCRIPTION
This PR contains

* A bug fix for which a feedback parameter was not added to the list of parameters when invoking a CArtAgO operation without any other parameter. This was due to a missing check in the code which defaulted to not adding anything in case of missing parameters (even if a feedback one was present).
* A bug fix for which using an empty HttpConfig object in the HypermediaArtifact made the URI of the artifact always begin with "http://localhost:8080" instead of the correct URI. This was due to not using the right configuration object inherited from the Vert.X verticle on which the class was being created.